### PR TITLE
Make OWFS hub searching more robust

### DIFF
--- a/oxc.pl
+++ b/oxc.pl
@@ -559,10 +559,21 @@ sub set_path {
 	# read the file for temp information. owfs format is slightly different than serial #s
 	# ie 103A8CE400080002 = 10.3A8CE400080000
 
-	for my $index (0..$#OWFS_hubs) {
+	&xAP::Util::debug("Testing OWFS for $sensor");
+	my $sensor_owfs_name = substr($sensor,0,2) . "." . substr($sensor,2,10) . "00";
 
-	  my $owfs_file = $root . $OWFS_hubs[$index] . substr($sensor,0,2) . "." . substr($sensor,2,10) . "00";
-	  $self->{Path} = $owfs_file if (-e $owfs_file);
+	foreach my $hub (@OWFS_hubs) {
+	  my $hub_filename = $root . $hub;
+	  &xAP::Util::debug("Testing OWFS: Looking in hub: $hub_filename");
+	  my @file_list = glob($hub_filename . "*");
+
+	  foreach my $filename (@file_list) {
+	    if ($filename =~ /$sensor_owfs_name/) {
+	      $self->{Path} = $hub_filename . $sensor_owfs_name;
+	      last;
+	    }
+	  }
+
 	  if ($self->{Path}) {
 		&xAP::Util::debug("OWFS Path for $sensor is $self->{Path}");
 		return $self->{Path};


### PR DESCRIPTION
I am running on Ubuntu 16.04 with recent updates and OWFS 3.1.

OWFS is reporting the 1-wire sensor filename existing on all channels when OXC conducted its search. The perl test using "-e" is always successful at line 565 in oxc.pl. When OXC tries to read the temp sensor from the wrong channel then it fails. This is the same behaviour as experienced on the command line.

This commit makes the search more robust. It checks whether the sensor is listed in the OWFS directory, rather than asking OWFS if the sensor filename exists. 